### PR TITLE
fix: scan block transactions as hashes

### DIFF
--- a/app/api/scan/route.ts
+++ b/app/api/scan/route.ts
@@ -323,14 +323,12 @@ export async function GET(request: NextRequest) {
 
     for (let blockNumber = startBlock; blockNumber <= latestBlock; blockNumber++) {
       try {
-        const block = await provider.getBlock(blockNumber, true);
+        const block = await provider.getBlock(blockNumber);
         if (!block || !block.transactions) continue;
 
-        const transactions = block.transactions as string[];
-        
+        const transactions = block.transactions;
+
         for (const txHash of transactions) {
-          if (typeof txHash !== 'string') continue;
-          
           const tx = await provider.getTransaction(txHash);
           if (!tx || tx.to !== null) continue;
           


### PR DESCRIPTION
## Summary
- ensure block scanning uses transaction hashes instead of full transaction objects

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (prompted for ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_68974ed5e1908330ab5114a3ec5c765e