### PR TITLE
Refactor scan logic into modular components with parallel processing

### DIFF
--- a/lib/scan/db.ts
+++ b/lib/scan/db.ts
@@ -1,0 +1,29 @@
+import { saveTokenDeployment, saveScanHistory } from '@/lib/database';
+import type { TokenContract } from './types';
+
+export async function recordTokenDeployment(token: TokenContract): Promise<void> {
+  try {
+    await saveTokenDeployment(token);
+    console.log(`✅ Saved to DB: ${token.metadata.symbol} at ${token.contract_address}`);
+  } catch (dbError) {
+    console.error('Database save error:', dbError);
+  }
+}
+
+export async function recordScanHistory(history: {
+  chain: string;
+  blocks_scanned: number;
+  total_contracts: number;
+  lp_contracts: number;
+  success_rate: number;
+  scan_time: string;
+  scan_duration_ms?: number;
+  error_message?: string;
+}): Promise<void> {
+  try {
+    await saveScanHistory(history);
+    console.log(`📊 Saved scan history for ${history.chain}`);
+  } catch (dbError) {
+    console.error('Error saving scan history:', dbError);
+  }
+}

--- a/lib/scan/liquidity.ts
+++ b/lib/scan/liquidity.ts
@@ -1,0 +1,55 @@
+import { ethers } from 'ethers';
+
+export async function checkLiquidity(
+  tokenAddress: string,
+  provider: ethers.Provider,
+  chainConfig: {
+    uniswapV2Factory: string;
+    uniswapV3Factory: string;
+    wethAddress: string;
+  }
+): Promise<{ v2: boolean; v3: boolean; status: string }> {
+  try {
+    let v2Exists = false;
+    let v3Exists = false;
+
+    try {
+      const v2Factory = new ethers.Contract(
+        chainConfig.uniswapV2Factory,
+        ['function getPair(address tokenA, address tokenB) view returns (address pair)'],
+        provider
+      );
+      const pairAddress = await v2Factory.getPair(tokenAddress, chainConfig.wethAddress);
+      v2Exists = pairAddress !== '0x0000000000000000000000000000000000000000';
+    } catch (error) {
+      console.error('V2 check error:', error);
+    }
+
+    try {
+      const v3Factory = new ethers.Contract(
+        chainConfig.uniswapV3Factory,
+        ['function getPool(address tokenA, address tokenB, uint24 fee) view returns (address pool)'],
+        provider
+      );
+      const feeTiers = [500, 3000, 10000];
+      for (const fee of feeTiers) {
+        const poolAddress = await v3Factory.getPool(tokenAddress, chainConfig.wethAddress, fee);
+        if (poolAddress !== '0x0000000000000000000000000000000000000000') {
+          v3Exists = true;
+          break;
+        }
+      }
+    } catch (error) {
+      console.error('V3 check error:', error);
+    }
+
+    return {
+      v2: v2Exists,
+      v3: v3Exists,
+      status: v2Exists || v3Exists ? 'YES' : 'NO'
+    };
+  } catch (error) {
+    console.error('Error checking liquidity:', error);
+    return { v2: false, v3: false, status: 'ERROR' };
+  }
+}

--- a/lib/scan/metadata.ts
+++ b/lib/scan/metadata.ts
@@ -1,0 +1,41 @@
+import { ethers } from 'ethers';
+
+export async function getTokenMetadata(
+  contractAddress: string,
+  provider: ethers.Provider
+): Promise<{ name: string; symbol: string; decimals: number; total_supply: number }> {
+  try {
+    const contract = new ethers.Contract(
+      contractAddress,
+      [
+        'function name() view returns (string)',
+        'function symbol() view returns (string)',
+        'function decimals() view returns (uint8)',
+        'function totalSupply() view returns (uint256)'
+      ],
+      provider
+    );
+
+    const [name, symbol, decimals, totalSupply] = await Promise.all([
+      contract.name().catch(() => 'Unknown'),
+      contract.symbol().catch(() => 'UNKNOWN'),
+      contract.decimals().catch(() => 18),
+      contract.totalSupply().catch(() => '0')
+    ]);
+
+    return {
+      name,
+      symbol,
+      decimals: Number(decimals),
+      total_supply: Number(ethers.formatUnits(totalSupply, decimals))
+    };
+  } catch (error) {
+    console.error('Error getting token metadata:', error);
+    return {
+      name: 'Unknown',
+      symbol: 'UNKNOWN',
+      decimals: 18,
+      total_supply: 0
+    };
+  }
+}

--- a/lib/scan/scanBlocks.ts
+++ b/lib/scan/scanBlocks.ts
@@ -1,0 +1,69 @@
+import { ethers } from 'ethers';
+import { getTokenMetadata } from './metadata';
+import { checkLiquidity } from './liquidity';
+import type { TokenContract } from './types';
+import { recordTokenDeployment } from './db';
+
+export async function scanBlocks(
+  provider: ethers.Provider,
+  chainConfig: {
+    name: string;
+    chainId: number;
+    isOpStack: boolean;
+    explorerUrl: string;
+    wethAddress: string;
+    uniswapV2Factory: string;
+    uniswapV3Factory: string;
+  },
+  startBlock: number,
+  latestBlock: number
+): Promise<TokenContract[]> {
+  const results: TokenContract[] = [];
+  const blockNumbers = Array.from({ length: latestBlock - startBlock + 1 }, (_, i) => startBlock + i);
+
+  await Promise.all(blockNumbers.map(async blockNumber => {
+    try {
+      const block = await provider.getBlock(blockNumber, true);
+      if (!block || !block.transactions) return;
+
+      const txHashes = block.transactions as string[];
+      await Promise.all(txHashes.map(async txHash => {
+        if (typeof txHash !== 'string') return;
+        const tx = await provider.getTransaction(txHash);
+        if (!tx || tx.to !== null) return;
+
+        const receipt = await provider.getTransactionReceipt(tx.hash);
+        if (!receipt || !receipt.contractAddress) return;
+
+        const [metadata, lpInfo] = await Promise.all([
+          getTokenMetadata(receipt.contractAddress, provider),
+          checkLiquidity(receipt.contractAddress, provider, chainConfig)
+        ]);
+
+        if (metadata.name === 'Unknown' && metadata.symbol === 'UNKNOWN') return;
+
+        const result: TokenContract = {
+          chain: chainConfig.name,
+          chain_id: chainConfig.chainId,
+          is_op_stack: chainConfig.isOpStack,
+          block: blockNumber,
+          hash: tx.hash,
+          deployer: tx.from,
+          contract_address: receipt.contractAddress,
+          timestamp: new Date(block.timestamp * 1000).toISOString(),
+          metadata,
+          lp_info: lpInfo,
+          explorer_url: `${chainConfig.explorerUrl}/address/${receipt.contractAddress}`
+        };
+
+        results.push(result);
+        await recordTokenDeployment(result);
+        console.log(`Found token: ${metadata.symbol} at ${receipt.contractAddress}`);
+      }));
+    } catch (error) {
+      console.error(`Error processing block ${blockNumber}:`, error);
+    }
+  }));
+
+  return results;
+}

--- a/lib/scan/types.ts
+++ b/lib/scan/types.ts
@@ -1,0 +1,28 @@
+export interface TokenContract {
+  chain: string;
+  chain_id: number;
+  is_op_stack: boolean;
+  block: number;
+  hash: string;
+  deployer: string;
+  contract_address: string;
+  timestamp: string;
+  metadata: {
+    name: string;
+    symbol: string;
+    decimals: number;
+    total_supply: number;
+  };
+  lp_info: {
+    v2: boolean;
+    v3: boolean;
+    status: string;
+  };
+  dex_data?: {
+    price_usd: string;
+    volume_24h: string;
+    liquidity: string;
+    dex: string;
+  };
+  explorer_url: string;
+}


### PR DESCRIPTION
## Summary
- factor out liquidity, metadata, database, and block scanning utilities into `lib/scan`
- streamline scan API route by using new modular helpers
- process blocks and transactions concurrently to speed up scans

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(interactive prompt, requires configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6898398873c48330891c2bd71c2dcd0b